### PR TITLE
Do not chmod bashrc or run it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ ADD ./bin /swift/bin
 RUN	chmod +x /swift/bin/*
 
 ADD	./misc/bashrc /swift/.bashrc
-RUN	chmod u+x /swift/.bashrc; /swift/.bashrc
 
 RUN	cp /usr/local/src/swift/test/sample.conf /etc/swift/test.conf
 


### PR DESCRIPTION
This fails builds with:

```
/bin/sh: 1: /swift/.bashrc: Text file busy
```

This command is not necessary; bashrc are sourced not executed.